### PR TITLE
Ignore newlines from stdin

### DIFF
--- a/xprompt.c
+++ b/xprompt.c
@@ -580,6 +580,10 @@ parsestdin(FILE *fp)
 	rootitem = NULL;
 
 	while (fgets(buf, BUFSIZ, fp) != NULL) {
+		/* discard empty lines */
+		if (*buf && *buf == '\n')
+			continue;
+
 		/* get the indentation level */
 		level = strspn(buf, "\t");
 


### PR DESCRIPTION
Right now the program segfaults when there is an empty line in the input, and it's pretty easy for one to slip into your options if you are joining the output of several commands. With this patch, they are just ignored.